### PR TITLE
A couple little tweaks

### DIFF
--- a/Comment String XREFs.py
+++ b/Comment String XREFs.py
@@ -2,7 +2,7 @@
 # Add a comment at every XREF to a string (from the __cstring segment).
 # This only seems to be necessary on ARM.
 #
-# Samuel Groß <dev@samuel-gross.de> - github.com/saelo
+# Samuel Gross <dev@samuel-gross.de> - github.com/saelo
 #
 
 def readString(addr):

--- a/Find C Strings (ASCII).py
+++ b/Find C Strings (ASCII).py
@@ -10,7 +10,7 @@ def is_valid_ascii(byte):
 def is_null(byte):
   return byte == 0x00
 
-MIN_LEN = 4
+MIN_LEN = 8
 
 num_strings = 0
 start_string = 0
@@ -21,9 +21,14 @@ for seg_id in range(0, doc.getSegmentCount()):
 
   seg_start = seg.getStartingAddress()
   seg_stop = seg_start + seg.getLength()
+  seg_len = seg.getLength()
 
+  i = 0
   for adr in range(seg_start, seg_stop):
     val = seg.readByte(adr)
+    i += 1
+    if (i % 10000 == 0):
+        doc.log("%.1f%% " % (i * 100.0 / seg_len) )
 
     if is_valid_ascii(val):
       string_len += 1

--- a/To String.py
+++ b/To String.py
@@ -1,7 +1,7 @@
 #
 # Turn the current selection into an ASCII string.
 #
-# Samuel Groß <dev@samuel-gross.de> - github.com/saelo
+# Samuel Gross <dev@samuel-gross.de> - github.com/saelo
 #
 
 doc = Document.getCurrentDocument()


### PR DESCRIPTION
This diff changes the behavior of the string finder to require a longer sequence of printable characters before declaring a match - too many false positives with MIN_LEN=4 - and adds a progress meter when searching through large sections of code.

@0x90 makes sense?

@saelo - sorry to have to transliterate your name (I have the same problem with the umlaut) but on my machine Hopper complains about invalid character encoding