### PR TITLE
Improvements in Add CFString Inline Comments

### DIFF
--- a/Add CFString Inline Comments.py
+++ b/Add CFString Inline Comments.py
@@ -9,7 +9,7 @@ ENDIANNESS = "<" # Little endian = <, Big endian = >
 
 # helper methods
 def read_data(segment, addr, dlen):
-    if segment == None:
+    if segment is None:
         segment = doc.getSegmentAtAddress(addr)
     return "".join([chr(segment.readByte(addr+x)) for x in range(0,dlen)])
 
@@ -48,7 +48,7 @@ for addr in xrange(cfstring_range.getStartingAddress(), cfstring_range.getStarti
     for xref in cfstring_seg.getReferencesOfAddress(addr):
         xref_seg = doc.getSegmentAtAddress(xref)
         existing_inline_comment = xref_seg.getInlineCommentAtAddress(xref)
-        if existing_inline_comment == None or existing_inline_comment.startswith("0x"):
+        if existing_inline_comment is None or existing_inline_comment.startswith("0x"):
             cstr_data = str(read_data(None, cstr_ptr, cstr_len))
             doc.log("Set inline comment at 0x%x: %s"%(xref, repr(cstr_data)))
             xref_seg.setInlineCommentAtAddress(xref, "@" + repr(cstr_data))

--- a/Add CFString Inline Comments.py
+++ b/Add CFString Inline Comments.py
@@ -20,7 +20,14 @@ for seg_idx in range(0,doc.getSegmentCount()):
     cur_seg = doc.getSegment(seg_idx)
     if cur_seg.getName() == "__cfstring":
         cfstring_seg = cur_seg
+        cfstring_range = cur_seg
         break
+    elif cur_seg.getName() == "__DATA":
+        for section in cur_seg.getSectionsList():
+            if section.getName() == "__cfstring":
+                cfstring_seg = cur_seg
+                cfstring_range = section
+                break
 if not cfstring_seg:
     raise Exception("No CFString segment found")
 
@@ -28,7 +35,7 @@ if not cfstring_seg:
 ptr_size = 4
 if doc.is64Bits():
     ptr_size = 8
-for addr in xrange(cfstring_seg.getStartingAddress(), cfstring_seg.getStartingAddress()+cfstring_seg.getLength(), ptr_size*4):
+for addr in xrange(cfstring_range.getStartingAddress(), cfstring_range.getStartingAddress()+cfstring_range.getLength(), ptr_size*4):
     if doc.is64Bits():
         cstr_ptr, = struct.unpack(ENDIANNESS+"Q", read_data(cfstring_seg, addr + ptr_size*2, ptr_size))
     else:

--- a/Add CFString Inline Comments.py
+++ b/Add CFString Inline Comments.py
@@ -11,7 +11,7 @@ ENDIANNESS = "<" # Little endian = <, Big endian = >
 def read_data(segment, addr, dlen):
     if segment is None:
         segment = doc.getSegmentAtAddress(addr)
-    return "".join([chr(segment.readByte(addr+x)) for x in range(0,dlen)])
+    return "".join(chr(segment.readByte(addr+x)) for x in range(0,dlen))
 
 # first, find the CFString segment
 doc = Document.getCurrentDocument()

--- a/Add CFString Inline Comments.py
+++ b/Add CFString Inline Comments.py
@@ -43,5 +43,5 @@ for addr in xrange(cfstring_seg.getStartingAddress(), cfstring_seg.getStartingAd
         existing_inline_comment = xref_seg.getInlineCommentAtAddress(xref)
         if existing_inline_comment == None or existing_inline_comment.startswith("0x"):
             cstr_data = str(read_data(None, cstr_ptr, cstr_len))
-            doc.log("Set inline comment at 0x%x: %s"%(xref, cstr_data))
-            xref_seg.setInlineCommentAtAddress(xref, "@\"%s\""%cstr_data)
+            doc.log("Set inline comment at 0x%x: %s"%(xref, repr(cstr_data)))
+            xref_seg.setInlineCommentAtAddress(xref, "@" + repr(cstr_data))

--- a/Add CFString Inline Comments.py
+++ b/Add CFString Inline Comments.py
@@ -2,7 +2,7 @@
 # This is only really needed on ARM.  It seems to happen already on x64
 # bradenthomas@me.com
 
-import struct,sys
+import struct
 
 # configuration parameters, adjust as needed:
 ENDIANNESS = "<" # Little endian = <, Big endian = >

--- a/Add CFString Inline Comments.py
+++ b/Add CFString Inline Comments.py
@@ -33,15 +33,9 @@ if not cfstring_seg:
 
 # Run though CFStrings
 ptr_size = 8 if doc.is64Bits() else 4
+struct_typechar = "Q" if doc.is64Bits() else "I"
 for addr in xrange(cfstring_range.getStartingAddress(), cfstring_range.getStartingAddress()+cfstring_range.getLength(), ptr_size*4):
-    if doc.is64Bits():
-        cstr_ptr, = struct.unpack(ENDIANNESS+"Q", read_data(cfstring_seg, addr + ptr_size*2, ptr_size))
-    else:
-        cstr_ptr, = struct.unpack(ENDIANNESS+"I", read_data(cfstring_seg, addr + ptr_size*2, ptr_size))
-    if doc.is64Bits():
-        cstr_len, = struct.unpack(ENDIANNESS+"Q", read_data(cfstring_seg, addr + ptr_size*3, ptr_size))
-    else:
-        cstr_len, = struct.unpack(ENDIANNESS+"I", read_data(cfstring_seg, addr + ptr_size*3, ptr_size))
+    cstr_ptr, cstr_len = struct.unpack(ENDIANNESS + struct_typechar * 2, read_data(cfstring_seg, addr + ptr_size * 2, ptr_size * 2))
 
     for xref in cfstring_seg.getReferencesOfAddress(addr):
         xref_seg = doc.getSegmentAtAddress(xref)

--- a/Add CFString Inline Comments.py
+++ b/Add CFString Inline Comments.py
@@ -32,9 +32,7 @@ if not cfstring_seg:
     raise Exception("No CFString segment found")
 
 # Run though CFStrings
-ptr_size = 4
-if doc.is64Bits():
-    ptr_size = 8
+ptr_size = 8 if doc.is64Bits() else 4
 for addr in xrange(cfstring_range.getStartingAddress(), cfstring_range.getStartingAddress()+cfstring_range.getLength(), ptr_size*4):
     if doc.is64Bits():
         cstr_ptr, = struct.unpack(ENDIANNESS+"Q", read_data(cfstring_seg, addr + ptr_size*2, ptr_size))


### PR DESCRIPTION
The script `Add CFString Inline Comments` is important for iOS9/ARM64 apps, which Hopper has a problem with regarding CFString references. Since `__cfstring` is a section rather a segment, the script didn't work at all. Beside fixing this issue, I also cleaned/simplified/optimized the code a bit.
